### PR TITLE
remove 2nd link to repo since Corner already links

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,7 @@
   <div id="app"></div>
   <div id="footer">
     Made by
-    <a href="https://amilajack.com">Amila Welihinda</a>|
-    <a href="https://github.com/amilajack/drum-machine">Code on GitHub</a>
+    <a href="https://amilajack.com">Amila Welihinda</a>
   </div>
   <script src="./src/main.js"></script>
 </body>


### PR DESCRIPTION
The GitHub Corner already links to the repository, so removing the second link to the repository might reduce clutter.